### PR TITLE
Update philosophy document of the language

### DIFF
--- a/philosophy/00 foreword.md
+++ b/philosophy/00 foreword.md
@@ -11,63 +11,65 @@ Another thing which I tried to keep in mind, which I think bears repeating, is t
 
 > Code is more often read than it is written
 
-In short, I wanted to create a programming language that is not only easy to write, but also easy to read. 
-There's this thing called the "no free lunch theorem", which in this context basically means that there is no perfect solution to any problem. 
-Each potential advantage comes with its own set of disadvantages. 
-It is up to the engineer to weigh these trade-offs and make a, hopefully, well-informed decision. 
+In short, I wanted to create a programming language that is not only easy to write in, but also easy to read. 
+There's this thing called the "no free lunch theorem", which in this context basically means that there is never a perfect solution to a problem.
+Each potential solution comes with its own set of both advantage and disadvantages. 
+It is up to the individual, or team, to weigh these trade-offs and make a, hopefully, well-informed decision. 
 This also holds true for language design. 
-There are a near endless amount of design choices, each with advantages and disadvantages.
-Below I present some examples of such trade-offs and their accompanying thought process:
+There are a near endless amount of design choices, each of which come with their own set of advantages and disadvantages.
+Below I present some examples of such trade-offs, and the accompanying thought process:
 
-* Increased flexibility of the language makes it easier for a developer to express their ideas in the language.
-* At the same time, increased flexibility can make it harder to read for others as there suddenly are more ways to do the same thing.
-* Strong static typing rules allow us to catch errors which would otherwise only be raised during execution, when it might be too late.
-* But, enforcing types statically can potentially decrease flexibility and increase verbosity.
-* Explicit error handling makes developers more aware of what might go wrong and what will happen in those situations.
-* The increased verbosity of error handling however detracts somewhat from the elegance of the language.
+- Increased flexibility of the language should make it easier for a developer to express their ideas in the language.
+- At the same time, increased flexibility might mean there are more ways to do the same thing, which may lead to inconsistencies.
+- Static typing allow us to identify errors which would otherwise only be raised during execution, when it might already be too late.
+- However, enforcing types statically can potentially decrease flexibility and increase the verbosity of the language.
+- Explicit error handling makes developers more aware of what might go wrong and what will happen in those situations.
+- The increased verbosity of error handling mechanisms can however detract somewhat from the elegance of the language, and make code harder to read.
 
-The list just keeps on growing. Language design is tricky to say the least. 
+The list just keeps on growing.
+Language design is tricky to say the least. 
 I often see discussions online about what the supposed "best" programming language is. 
 Personally, I think this misses the point wholly. 
 A language, really, is just a tool to solve a certain set of problems. 
 Just like tools in a toolbox, certain languages are better suited for certain jobs. 
 I could tighten a screw with a hammer, but if I end up failing, that isn't the fault of the hammer, that's on me for picking the wrong tool. 
-Were I to construct a mathematical model, languages such as python and MATLAB are more well-suited. 
-If I wanted to create an embedded system, more low-level languages such as C or Rust or more suited, generally speaking.
+Were I to construct a mathematical model, languages such as python and MATLAB are probably more well-suited. 
+If I wanted to create an embedded system, I would favour more low-level languages such as C or Rust, generally speaking.
 
 Furthermore, the problems being solved also change over time. 
 That is why I dismiss the notion of a "perfect programming language". 
-A language is designed to solve a certain set of problems well, so there will always be something that a certain language, or tool, is not design to solve. 
-I can't imagine that the computer scientists of the 70's and 80's could've imagined that computers would become as wide-spread as they are today. 
-As of writing this, in most developed countries, computers have become ubiquitous. 
-Everyone seems to have in their pockets what not too long ago would've been called a supercomputer. 
+A language, generally speaking, is designed to solve a certain set of problems well.
+There will always be something that a certain language, or tool, is not design to solve. 
+It stands to reason that the computer scientists of the 70's and 80's couldn't have imagined that computers would become as ubiquitous as they are today.
 Machine learning has taken a foothold in most major industries, and the internet of things is starting to take off. 
 
 I will say that certain languages features, no matter how well intentioned they may have been, or insignificant they seemed at the time, may not have been the best choice in hindsight. 
-Lack of bounds checking can lead to buffer overflows, lack of null safety leads to undefined behaviour, and so on. 
-But hindsight is 20/20 as they say, and it is almost impossible to know how a language will be used in advance. 
+Not performing bounds checking on array accesses can result in buffer overflows, leading to many security exploits.
+Having the concept of null in a language without null safety can result in undefined behaviour, and also allows developers to circumvent the type system of a language, significantly reducing its effectiveness.
+However, hindsight is 20/20 as they say, and it is almost impossible to know how a language, or tools in general, will be used in advance. 
 Truth be told, it is almost certain that any tool will be abused in ways the creator could not have foreseen. 
 As the popular saying goes:
 
 > A tool is either not used, or complained about
 
 Still, over time, I think that we have gotten better at language design. 
-Common patterns might be taken into account when designing a language, allowing for more elegant idiomatic solutions. 
-This is especially true with domain specific languages. 
-Better still, mistakes can be discouraged or simply be made obsolete through language features. 
+Common patterns might be taken into account when designing a language, allowing for more elegant and idiomatic solutions to common problems. 
+This holds especially for domain specific languages. 
+I also think that it is possible to discourage, or make impossible, certain common mistakes made through language design.
+For instance, making it impossible to return null values within methods unless explicitly stated that it may do so.
 
-Personally, when talking about general purpose languages (as opposed to more domain specific languages), I believe we should stave off the temptation to add too many language features. 
-A certain balance should be kept, or the language can, to my mind, start to feel asymmetric. 
-This is something I also struggled with during the design phase. 
+Personally, I think that when talking about general purpose languages (as opposed to more domain specific languages), a certain amount of restraint is necessary with regards to introducing features.
+Too many features can result in a very steep learning curve, and might result in many possible ways of doing the same thing.
+This is something I also struggled with during the design phase of the language. 
 Certain feature might allow very specific problems to be solved idiomatically, but at a point lines have to be drawn, or we run into some issues:
 
-* If I add a language feature to solve problem A, why should I not add one so we can more efficiently solve problem B? What about problem C?
-* Every new feature added to a language increases its complexity, making it more difficult to write and read.
-* Every new feature added has the potential to add yet another way to solve the same problem, potentially making the language more complex.
+- If I add a language feature to solve problem A, why should I not add one so we can more efficiently solve problem B? What about problem C?
+- Every new feature added to a language increases its complexity, making it more difficult to write and read.
+- Every new feature added has the potential to add yet another way to solve the same problem, potentially making the language more complex.
 
-No language is perfect, including this one. 
+No language is perfect, including Mamba. 
 As stated before, I think that it is impossible to design a perfect language. 
-People, problems, how and where computers are used, changes over time, and different domains have different requirements and challenges. 
+How computers are used and what problems are being solved changes over time, and different domains have different requirements and challenges. 
 Nevertheless, I always think that it's worth to try to improve upon past decisions, and see where that might lead us.
 
 Joël Abrahams, 2019

--- a/philosophy/01 general features.md
+++ b/philosophy/01 general features.md
@@ -3,7 +3,8 @@
 Here I outline in short some of the core features of Mamba, and their motivation, and to reveal a bit of the philosophy behind the language.
 These are covered in greater detail in their respective chapters. 
 
-There are multiple programming paradigms in computer science, as can be seen below in this non-exhaustive list:
+There are multiple programming paradigms in computer science.
+A few of the popular one's are outlined in this short, non-exhaustive list:
 
 Paradigm                     | Description
 -----------------------------|-------------
@@ -13,145 +14,235 @@ Functional Programming       | Treat computation as a mathematical function, wit
 
 Each come with their own (or overlapping) set of philosophies and schools of thought. 
 Certain languages stick to a single paradigm. 
-SmallTalk for instance sticks to object oriented programming, and Haskell to functional programming.
+SmallTalk, for instance, sticks to object oriented programming, and Haskell to functional programming.
 Java has stuck mostly to object oriented, though it does make an exception for primitives, and has retroactively added features found in functional languages such as anonymous functions.
 
 Mamba aims to provide a mix of the object oriented and functional programming paradigms.
-Crudely speaking, it aims to improve upon Python by providing types and other features that make it easier to write bug-free code.
+It aims to improve upon Python by introducing static type checking, null safety, and a bunch of other features, such as type refinement.
 We also use features from other languages which have proven successful over time.
 
 ## Syntax, Syntax Sugar, and Readability
 
 One thing that can significantly hinder the readability of source code is syntax noise. 
-One way to combat this is through use of syntax sugar, which allows programmers to, ideally, express their ideas in a more elegant manner. 
-Syntax sugar however comes with its own set of problems.
-The same idea can be expressed in more than one way, increasing the cognitive load of reviewing code and learning the language.
+Therefore, I tried to limit the amount of symbols and keywords in the language.
+I believe that when reading a piece of code, one should be able to understand what is happening without being hindered by excessive syntax.
 
-We therefore aim to use syntax sugar sparingly, but still often enough so the language does not become too verbose.
+One way to make code "look" more elegant, and ideally more readable, is through use of syntax sugar.
+This allows developers to, ideally, express their ideas in a more elegant manner. 
+Syntax sugar however comes with its own set of problems, one of which is that it can introduce a new way of solving the same problem.
+We therefore aim to use syntax sugar sparingly, but still often enough so the language does not become overly verbose.
 A few examples are shown below:
 
-* Functions and methods with no arguments, or a single argument, can be called without brackets.
-* In a `foreach`, if we iterate over a collection of tuples, we can omit the brackets.
-* We can define a range using `..` and `..=`.
-* The negation of equality `eq` is `neq`, instead of having to negate the equality using `not`.
+- Functions and methods with no arguments, or a single argument, can be called without brackets.
+- In a `foreach`, if we iterate over a collection of tuples, we can omit the brackets (just as in Python).
+- We can define a range using `..` and `..=`.
+- The negation of equality `=` is `/=`, instead of having to negate the entire equality using `not`.
 
-For the sake of readability, we also decrease the reliance of symbols, which may be another source of syntax noise, decreasing the readability of the language.
+As stated before, we also decrease the reliance on symbols, which may be another source of syntax noise.
 This should make the language more closely map to the english language, but not so close as to introduce ambiguity into the language.
 A few examples are given below:
 
-* Use `and` instead of `&&`, i.e. `alice.is_online and bob.is_online` instead of `alice.is_online && bob.is_online`.
-  Or even `alice is_online and bob is_online`.
-* Use `or` instead of `||`, i.e.  `foo() or bar()` instead of `foo() || bar()`.
-* Use `not` instead of `!`, i.e. `if not productive then drink_coffee()` instead of `if !productive then drink_coffee()`.
-* Use indentation to denote code blocks instead of `{` and `}`.
+- Use `and` instead of `&&`, i.e. `alice.is_online and bob.is_online` instead of `alice.is_online && bob.is_online`.
+  We can even write `alice is_online and bob is_online`.
+- Use `or` instead of `||`, i.e.  `foo() or bar()` instead of `foo() || bar()`.
+- Use `not` instead of `!`, which can easily be missed when read. 
+  So we write `if not productive then drink_coffee()` instead of `if !productive then drink_coffee()`.
+- Use indentation to denote code blocks instead of `{` and `}`, just as in Python.
 
 Mamba also uses arrow notation to more clearly denote the flow of data:
-* `<-` is used to assign to variables. 
+- `<-` is used to assign to variables. 
   It denotes data flowing from the expression on the right to the identifier on the left.
-* `->` is used to denote (anonymous) functions.
-  It denotes variables assigned to the arguments on the left flowing into the body of the function.
-* `=>` is used to denote the control flow of the application.
+- `=>` is used to denote the control flow of the application.
   This is used for two reasons:
-  * It more clearly differentiates data manipulation from application control flow.
-  * It avoid ambiguity in the grammar by differentiating anonymous functions from control flow in certain situations.
+  - It more clearly differentiates data manipulation from application control flow.
+  - It avoid ambiguity in the grammar by differentiating anonymous functions from control flow in certain situations.
+- `->` is used within type definitions of functions and methods.
 
-This combined with (sparing) use of syntax sugar should ideally make the language easier to read.
+This, combined with (sparing) use of syntax sugar, should ideally make the language easier to read.
 Take for instance the following piece of code:
 
-    foreach composer in composers
+    foreach composer in composers do
         if composer.death is undefined then
             println "[composer] has not died."
         else 
-            def years_ago -> today - composer.death
-            pintln "[composer] died [years_ago] years ago"
+            def years_ago <- today - composer.death
+            print "[composer] died [years_ago] years ago."
             
 Without any knowledge of Mamba, the reader should ideally, when reading above, be able to deduce that:
 
-* We are iterating over a set (or collection) of composers.
-* We are checking whether a composer has died.
-* If a composer has died, we print how long ago that was. 
+- We are iterating over a set (or collection) of composers.
+- We are checking whether a composer has died.
+- If a composer has died, we print how long ago that was. 
   Presumably today is a date.
 
 Notice how little program specific syntax there is:
  
-* We use `[` `]` to insert variables into strings.
-* We use `:` to denote what type `ago` is.
-* `if` and `else` are used for program flow, and `println` to print something to the screen.
-  * Note how we use the postfix notation when calling `println`, so we don't need to wrap the whole string in brackets.
-* Indentation is used to denote code blocks, making it easy for the eyes to follow what is being done where and when.
+- We use `[` and `]` to insert variables into strings.
+- We use `:` to denote what type `ago` is.
+- `if` and `else` are used for program flow, and `print` to print something to the screen.
+  - Note how we use the postfix notation when calling `print`, so we don't need to wrap the whole string in brackets.
+- Indentation is used to denote code blocks, making it easy for the eyes to follow what is being done where and when.
 
-On a final note, I'd like to say that I believe the syntax of Python to be one of the most elegant.
-I once heard someone say:
+## Null Safety
 
-> When writing pseudocode, I end up writing Python code
-
-That also happens to be the original intent of Mamba, when I started creating the language.
-I wanted to create a language that felt and looked like pseudocode.
-Only during the second attempt when designing the language did I stumble upon the idea to closely map the language syntax to that of the python language.
-
-In the following chapters however I do elaborate on some features that Mamba has that aim to improve upon the Python language.
-Let it be said however that I do not think that Python is a bad language by any stretch of the imagination.
-It is a language I hold much respect for, and one that I enjoy writing code in.
-
-## Null Safety, and Error Handling
-
-The `null` value, or the `undefined` value in cases of language such Javascript or Mamba, is value which is meant to symbolize the concept of nothing.
-It can be useful in some cases. 
-Implemented poorly in a language however it is often the root cause of the null pointer exception, error, or whatever terminology one wishes to use, the bane of many a programmer.
-It has lead to headlines similar to the following:
+The `null` value, or the `undefined` value in cases of Mamba, is value which is meant to symbolize the concept of nothing.
+It can be useful in some cases.
+Implemented poorly in a language however can make the language unwieldy to use, and can result in many bugs.
+It has lead to headlines akin to:
 
 > Null Pointers, the billion dollar mistake
 
 Null values can either break the application flow of an application by throwing an exception, such as in Java, or simply result in undefined behaviour, such as in C++.
 A language with no null safety basically nullifies much of the functionality of a type system.
-If I write a method, and I say that it returns an integer, a user of said function should not have to worry about the potential of the return value potentially being `null` or undefined unless explicitly stated.
+If I write a method, and I say that it returns an integer, a user of said method should not have to worry about the return value potentially being `null`.
 Over the years, multiple languages have tried to implement null safety, with the two prevailing strategies being as follows:
 
-* The language does not contain `null` as a concept, but has a monad, often called an `Optional`, which can either be a value or nothing.
-* `null` safety is baked into the language, and is enforced by the type system itself.
-  This is for instance the approach that Kotlin uses.
+- The language does not contain `null` as a concept, but has a monad.
+  This often called an `Optional`, and can either be `None`, or `Some`, with `Some` wrapping the desired value.
+- Null safety is baked into the language, and is enforced by the type system itself.
+  This is for instance the approach that Kotlin uses, and in my opinion the less verbose option as well.
 
-Buffer overflows might however be the trillion dollar mistake.
-As with most language, it did opt to use bounds checking.
+Mamba bakes null safety into the language
+`?` is appended to types that may be `undefined`. 
+If this has not been appended, say in the signature of a method, this method may not return `undefined`.
+`?.` can be used on expressions that may be null, and it means a method is only called if the expression is not `undefined`.
+
+```
+# g never returns undefined. 
+# If we would try this we would get a type error.
+def g(x: Int): Int -> if x > 2 then x + 2 else x - 2
+
+# f may return undefined
+def f(x: Int): Int? -> if x > 2 then x * 7 else undefined
+
+def x <- f(2) ?. is_even() # is_even is called, and we get true
+def y <- f(3) ?. is_even() # f(3) is undefined, so is_even() is never called and y is now also undefined
+
+# note that both x and y have type Bool?, meaning that they may both be undefined.
+```
+
+As with most language, Mamba also uses bounds checking.
 However, unlike other scripting languages such as Ruby or Python, I opted to raise an error when we attempt to access outside the bounds of an array (or collection), much like languages such as Java.
 This should ideally make it easier to track down bugs, which might otherwise be undetected for some time.
 This adheres somewhat to the **fail fast** philosophy.
+
+## Error Handling
 
 Handling errors is something that is difficult to do well in language.
 As a developer, it can be difficult to determine where and when we should handle such errors.
 Doing this elegantly, whilst at the same time remaining explicit, is also difficult.
 
-## Mutability and Immutability
-
-Immutability, which allows us to change a value of a variable, brings with it great flexibility, but in certain
-situations this flexibility comes at the detriment of safety.
-
-When a variable is immutable, it should truly be immutable. Often I see that even when a variable is declared immutable,
-it is possible to modify it's internal fields in object oriented programming languages.
-
-## Type Safety
-
-In programming, there is often a distinction made between static and dynamic typing. 
-As stated before however, we want to only have checked Exceptions in our application. 
+We want to only have checked errors in our application. 
 Once we run an application, we expect its behaviour to reflect what was written.
 
+We also want to have a visual trace of what can go wrong within the source code. 
+This makes it easier to identify potential causes of errors, as opposed to wrapping everything in for instance a `try` `catch`, which may bury errors or make it unclear what statement, or line, was the actual source of the error.
+Therefore, we:
+- Explicitly state where errors occur using `raises`, such as inline or in the function signature
+- Use inline pattern matching, using `handle`, to encourage on-site error handling.
+
+We outline how this would be used:
+
+```
+# We show that this function raises a negative number
+def my_function(x: Int): Int raises [NegativeNumber] => if x < 0 then NegativeNumber else x * 10
+
+def z <- 4 + 6
+def y <- my_function(z) raises [NegativeNumber] # We state inline what this statement might throw
+
+def z <- my_function(z) handle
+  NegativeNumber => undefined # It might be good to log the error as well
+  other => other
+```
+
+Note that my_function could also return `undefined` directly.
+
+## Mutability and Statefulness, and Immutability and Statelessness
+
+Immutability, which allows us to change a value of a variable, brings with it great flexibility.
+In certain situations however, this flexibility may not be desirable and can be abused.
+Therefore, we want to be able to define something as immutable, meaning that it cannot be changed.
+
+When a variable is immutable however, it should truly be immutable. 
+Often I see that even when a variable is declared immutable, it is still possible to modify it's internal fields.
+
+Therefore, must like `Rust`, we specify whether `self` is mutable in the signature of a method.
+This means that methods which modify the internals of an object, can only be called if said object is mutable.
+
+```
+stateful MyStateful
+  def mut field <- 10
+
+  # can only be called if self is mutable
+  def method_1(mut self) => self.field <- 20 # we can assign because self is mutable
+
+  def method_2(self) => print "This doesn't modify anything."
+```
+
+`method_1` specifies that self must be mutable for it to be called.
+`method_2` may not modify the fields of `self` as `self` is not mutable.
+
+We also make a distinction between State and Statelessness, using `stateful` and `stateless`.
+Statlessness is often seen in functional programming languages.
+It also allows us to enfore the following rule: `forall f, x = y -> f(x) = f(y)`, as is the case in functional programming language.
+This might seem obivous to mathmaticians, but is not always the case when state is rought into play.
+Take the following
+
+```
+stateful MyStateful 
+  def mut called_before <- false
+
+  def f(x: Int): Int => if called_before then x * 2 else x * 3
+```
+
+Now we call the same method twice, and we see that it returns two different values:
+```
+def my_stateful <- MyStateful()
+
+my_stateful.f(10) # retuns 20
+my_stateful.f(10) # return 30
+```
+
+Ensuring that something has no state allows us to enforce the above rule, as the same function or method will always return the same value for the same input.
+In a `stateless`, we cannot have mutable top level definitions, which allows use to enforce this rules as its internal state can never change.
+
+```
+stateless MyStateless
+  def f(x: Int): Int => x * 2
+```  
+
+Now we always get the same value:
+```
+def my_stateless <- MyStateless()
+
+my_stateless.f(10) # returns 20
+my_stateless.f(10) # still returns 20
+```
+
+## Static Typing and Type Inference
+
+Often a distinction is made between static and dynamic typing. 
+
 If the application were dynamically typed, we would constantly have to verify that variables are indeed what they claim to be.
-I have a variable `beethoven`, but is that an instance of `Composer` or `Person`? How do I check this, what methods can I use?
+Say I have a variable `beethoven`, can I assume that it is an instance of `Composer`?
    
     # how can I be sure that this function argument is a composer?
-    def my_function (composer) -> composer.composer_method()
+    def my_function (composer) => composer.composer_method()
     
-To this end, we use types. A user defines a class `Composer`, which defines the behaviour of a composer:
+There are of course ways to check this, such as using the `isinstance` method in Python, but this is rather tiresome.
+To this end, we use types. 
+A user defines a class `Composer`, which defines the behaviour of a composer:
 
-    class Composer
+    stateless Composer
         def composer_method(): Int
     
 And then we define the `my_function` as such:
 
-    def my_function (composer: Composer): Int -> composer.composer_method()
+    def my_function (composer: Composer): Int => composer.composer_method()
     
 Now, in the body of the function, we can rest easy knowing that the passed variable is indeed a composer. 
-It is actually now impossible to pass another variable type to the function, as this is checked by the type checker, which will give an error, meaning that the program wil not run.
+It is actually now impossible to pass another variable type to the function, as this is statically checked by the type checker.
+If it sees that we try to pass something that is not a composer, will give an error, meaning that the program wil not run.
 
 In some programming languages, we have to explicitly state the type of each variable. 
 This however makes the application rather verbose. 
@@ -161,54 +252,58 @@ Take for instance:
     def c: Complex <- Complex(10, 20)    # from the right hand side it is already clear that c is complex
 
 Instead, we can use type inference. 
-The type of every variable is inferred from the expression on the right hand side.
+The type of every variable is inferred from the context in which it is used.
 
+```
     def x <- 10                 # x has type Int, we know this because 10 is an Int
     def c <- Complex(10, 20)    # c has type Complex
     def y <- 20.1               # 20.1 uses decimal notation, so we know y is a real number, or Real
     
     def z: Real <- 10.5         # In some situations however, you still might want to explicitly mention the type
+```
 
 The program is still statically typed, but now we don't require the developer to write everything out in full.
 
-I believe this to be a far superior system to dynamic typing, or duck typing.
-Type inference, to me, seems to be a nice compromise between having a strong static type system and low verbosity of a language, say Python.
-
 ### Type Aliases and Type Refinement
 
-We can also use type aliases and type refinement to further refine types by adding conditions to types:
+We can also use type aliases and type refinement to further refine types by adding conditions to them.
+Say we have the following:
 
     type DeadComposer <- Composer where
-        self.death isnt undefined else Err("Composer is not dead.")
+        self.death /= undefined else Err("Composer is not dead.")
 
 We now rewrite my_function so it only works for `DeadComposer`s:
 
-    def my_function (composer: DeadComposer): Int <- today.year - composer.death.year
+    def my_function (composer: DeadComposer): Int => today.year - composer.death.year
     
 Again, we can rest assured that `composer` is a `DeadComposer` in the body of the function. 
 To use such a function, we must explicitly cast a `Composer`:
 
+```
     def chopin <- Composers("Chopin")
     
-    if chopin isa DeadComposer
+    if chopin isa DeadComposer then
         def years_ago <- my_function(chopin)                    # chopin is dynamically casted to a DeadComposer
-        println ("[chopin.name] died [years_ago] years ago.")
+        print "[chopin.name] died [years_ago] years ago."
+```
 
 This draws on concepts of **Design by Contract** philosophy.
 
 Furthermore, it also allows us to explicitly define the state of an object, something which is often left ambiguous.
 For instance, we can say a server is connected or disconnected by doing the following:
 
+```
     type Server
         def private connected: Boolean
         def send_message(self: ConnectedServer, message: String): String
 
     type ConnectedServer isa Server where
         connected else Err("Server is not connected")
-        
+```
+
 And we may then elsewhere implement this `Server` interface:
 
-    class MyServer isa Server
+    stateful MyServer isa Server
         def private connected <- false
         
         def init() -> ...
@@ -218,5 +313,4 @@ And we may then elsewhere implement this `Server` interface:
         # You can only call this function if I am a connected server
         def send_message(self: ConnectedServer, message: String) -> ...
 
-This is a rather trivial example, but it shows how we can explicitly name the state of server.
-What a state entails is centrally defined, and ideally part of the interface, instead of spread of the entire code base, and it can also to some extent be checked by the type checker.
+This is a rather trivial example, but it shows how we can explicitly name the different states of a server.

--- a/philosophy/02 inspirations.md
+++ b/philosophy/02 inspirations.md
@@ -1,28 +1,29 @@
 # General inspirations of the language
 
-The following is a list of programming languages that inspired this one in one way or another. This can either be
-certain constructs or keywords in the language, or the philosophy of the language as a whole.
+The following is a list of programming languages that inspired this one in one way or another. 
+This can either be certain constructs or keywords in the language, or the philosophy of the language as a whole.
+It should be noted that this is based on my personal experience with these languages.
+It may be that a certain feature of a certain language did inspire a certain feature of Mamba, but that does not mean that another language does not contain said feature, only that I encountered it there first.
 
 Language  | Inspired
 ----------|------------
-Python    | Flexibility. Co-existence of functions and methods, or co-existence of functional and oop paradigms. Large portion of the syntax.
-Java      | OOP concepts. Strict typing rules.
-C#        | OOP concepts.
-Scala     | Everything is an object, including primitives of the language, pattern matching.
-Kotlin    | Ranges. Type aliases, relying in keywords to define common use cases instead of having to write everything out explicitly.
-Ada       | Custom data types (or type aliases) with ranges. Inspired use of type refinement. Strict typing rules. Natural language over symbols, such using `and` stead of `&&`.
-C++       | OOP concept.
-C         | General programming concepts, not so much a direct inspiration but a general influence.
-Eiffel    | Design by contract philosophy, the `retry` keyword. Design by contract inspired used of type refinement. 
-Haskell   | Pattern Matching. Lack of mutability. Closeness of mapping with mathematical notation, for instance set constructor notation.
-Rust      | Error handling mechanisms. Strict rules regarding mutability.
-Ruby      | Syntax sugar, postfix `if` operator. Philosophy that flexibility is not inherently a bad thing.
-Swift     | Error handling mechanisms.
-Go        | Error handling mechanisms, encouraging error handling on site.
-MATLAB    | Concepts of flexibility, certain syntax.
-SmallTalk | OOP concepts, emphasis on program state.
-JavaScript| Interchangeability of variables and functions. Flexibility.
-COBOL     | Use of natural language for clarity. But nowhere to the same extent.
+Python    | Flexibility. Co-existence of functional and oop paradigms. Large portions of the syntax.
+Java      | OOP concepts. Static typing rules.
+C#        | OOP concepts. Static typing rules and type inference.
+Scala     | That everything is an object, including primitives of the language. Pattern Matching.
+Kotlin    | Ranges baked into the language. Type aliases. Relying in keywords to define common use cases and patterns.
+Ada       | Custom data types (or type aliases) with ranges, which also inspired use of type refinement. Use of natural language over symbols, such as using `and` as opposed to `&&`.
+C++       | OOP concepts and operator overloading.
+C         | General programming concepts. Not so much a direct inspiration but more a general influence.
+Eiffel    | Design by contract philosophy andthe `retry` keyword. Design by contract also inspired the type refinement system. 
+Haskell   | Pattern Matching. Immutability. Closeness of mapping with mathematical notation, for instance set constructor notation.
+Rust      | Error handling mechanisms and strict rules regarding mutability.
+Ruby      | Portions of the syntax of the language.
+Swift     | Elegant error handling mechanisms.
+Go        | Error handling mechanisms, which encourage error handling on site.
+MATLAB    | Small portions of the syntax. 
+SmallTalk | OOP concepts, with a large emphasis on program state.
+JavaScript| Interchangeability of variables and functions, and a reliance on higher-order functions.
 Perl      | The `forward` keyword.
 
 My experience with each language varies greatly, from having used it on a near daily basis, to only having read about it online and only have a conceptual understanding of its workings.
@@ -34,13 +35,9 @@ I grouped them mostly by what I perceived to be their intended design goals.
 
 These are the scripting languages, and have proved to be very popular in the domain of web development.
 
-## C
- 
-The father of most modern programming languages.
- 
-## Rust, Go, and Ada
+## C, Rust, Go, and Ada
 
-These languages, much like C, are aimed at embedded systems, but provide some extra features.
+These are imperative programming languages.
 
 ## Java, C#, and C++
 
@@ -48,7 +45,7 @@ These are the historically famous object oriented languages.
 
 ## Kotlin, Swift, and Scala
 
-These new generation of object oriented programming languages aim to improve on the above.
+These new generation of object oriented programming languages which aim to improve upon the above.
 
 ## Smalltalk and Eiffel
 
@@ -61,4 +58,4 @@ It is a language that shows how much an ecosystem can define the language in whi
 
 ## Haskell
 
-The only purely functional programming language on the list.
+The only purely functional programming language on this list.

--- a/spec/00 grammar.md
+++ b/spec/00 grammar.md
@@ -48,11 +48,11 @@ The grammar of the language in Extended Backus-Naur Form (EBNF).
                       | "_"
                      
     reassignment     ::= expression "<-" expression
-    anon-fun         ::= "\" expression "=>" expression
+    anon-fun         ::= "\" id-maybe-type { "," id-maybe-type } "=>" expression
     call             ::= expression [ [ ( "." | "?." ) ] id ] ( tuple | expression )
     
     raises           ::= "raises" generics
-    handle           ::= "handle" "when" newline match-cases
+    handle           ::= "handle" newline match-cases
     
     collection       ::= tuple | set | list | map
     tuple            ::= "(" zero-or-more-expr ")"


### PR DESCRIPTION
- Use `stateless` and `stateful` terminology in Philosophy documentation, working towards #4.
- Fix grammar and spelling mistakes in philosophy documents.
- Update Further elaborate (incomplete) feature descriptions in `01 General Features.md` document.
- Remove `when` from `handle` statement.